### PR TITLE
Add "scan first match" function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,4 +236,40 @@ mod tests {
 
         assert_eq!(crate::scan(Cursor::new(bytes), &pattern).unwrap(), vec![]);
     }
+
+    #[test]
+    fn scan_first_match_simple_start() {
+        let bytes = [0x10, 0x20, 0x30, 0x40, 0x50];
+        let pattern = "10 20 30";
+
+        assert_eq!(
+            crate::scan_first_match(Cursor::new(bytes), &pattern)
+                .unwrap()
+                .unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn scan_first_match_simple_middle() {
+        let bytes = [0x10, 0x20, 0x30, 0x40, 0x50];
+        let pattern = "20 30 40";
+
+        assert_eq!(
+            crate::scan_first_match(Cursor::new(bytes), &pattern)
+                .unwrap()
+                .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn scan_first_match_no_match() {
+        let bytes = [0x10, 0x20, 0x30, 0x40, 0x50];
+        let pattern = "10 11 12";
+
+        assert!(crate::scan_first_match(Cursor::new(bytes), &pattern)
+            .unwrap()
+            .is_none());
+    }
 }


### PR DESCRIPTION
This PR adds a public function which just returns the first index at which a match was found for a pattern, rather than all the indices at which the byte string matches. The intended use for this function would be if one wishes to just test if a byte string matches a pattern at all, without consideration of the indices, or if one only requires the first index at which a match occurs. In such cases, this function is more efficient than the `scan` function, as it can return early as soon as a pattern is found, rather than continuing to search the rest of the byte string.